### PR TITLE
Bump the sbt-spiewak plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12]
+        scala: [2.12.13]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12]
+        scala: [2.12.13]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -109,12 +109,12 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.12.12)
+      - name: Download target directories (2.12.13)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-2.12.12-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.12.13-${{ matrix.java }}
 
-      - name: Inflate target directories (2.12.12)
+      - name: Inflate target directories (2.12.13)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val core = project
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-http4s-org",
-    addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.19.3"),
+    addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.20.1"),
     addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
   )
 
@@ -22,8 +22,8 @@ inThisBuild(
     organizationName := "http4s.org",
     publishGithubUser := "rossabaker",
     publishFullName := "Ross A. Baker",
-    baseVersion := "0.6",
-    crossScalaVersions := Seq("2.12.12"),
+    baseVersion := "0.7",
+    crossScalaVersions := Seq("2.12.13"),
     developers := List(
       Developer(
         "rossabaker",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.19.3")
+addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.20.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")


### PR DESCRIPTION
We should get out this mostly unscathed: I think all our repos are main instead of master.  If we've missed any, let's fix them.

Also lets us turn off fail fast, which I think we should do on the main repo, where the build is less stable.

Will release this as 0.7.0.