### PR TITLE
gitignore .bsp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tags
 
 .bloop
 .metals
+.bsp/


### PR DESCRIPTION
According to @amesgen, this is generated by sbt-spiewak-0.21, and I think it's why 0.8.0 ended up a snapshot.