### PR TITLE
Introduce `Http4sOrgScalaJSPlugin`

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -22,4 +22,4 @@ project.excludeFilters = [
    "scalafix-outputs"
 ]
 
-runner.dialect = scala212
+runner.dialect = scala212source3

--- a/core/src/main/scala/org/http4s/sbt/Http4sOrgScalaJSPlugin.scala
+++ b/core/src/main/scala/org/http4s/sbt/Http4sOrgScalaJSPlugin.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.sbt
+
+import explicitdeps.ExplicitDepsPlugin
+import org.scalajs.sbtplugin.ScalaJSPlugin
+import sbt._
+
+object Http4sOrgScalaJSPlugin extends AutoPlugin {
+
+  override def trigger = allRequirements
+
+  override def requires = Http4sOrgPlugin && ScalaJSPlugin
+
+  import ExplicitDepsPlugin.autoImport._
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    unusedCompileDependenciesTest := {} // Doesn't work for Scala.js
+  )
+
+}


### PR DESCRIPTION
Having a plugin triggered by `ScalaJSPlugin` is one way to get "`ThisBuild`"-level defaults.