### PR TITLE
Don't check scalafixes on Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,6 @@ jobs:
       - name: Test
         run: sbt '++${{ matrix.scala }}' test
 
-      - name: Check scalafix lints
-        if: matrix.java == 'temurin@8'
-        run: sbt '++${{ matrix.scala }}' 'scalafixAll --check'
-
       - name: Check binary compatibility
         if: matrix.java == 'temurin@8'
         run: sbt '++${{ matrix.scala }}' mimaReportBinaryIssues
@@ -119,6 +115,10 @@ jobs:
       - name: Generate API documentation
         if: matrix.java == 'temurin@8'
         run: sbt '++${{ matrix.scala }}' doc
+
+      - name: Check scalafix lints
+        if: matrix.java == 'temurin@8' && !startsWith(matrix.scala, '3.')
+        run: sbt '++${{ matrix.scala }}' 'scalafixAll --check'
 
       - name: Check unused compile dependencies
         if: matrix.java == 'temurin@8'

--- a/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
+++ b/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
@@ -27,6 +27,7 @@ import ExplicitDepsPlugin.autoImport._
 import GenerativeKeys._
 import TypelevelKernelPlugin._
 import autoImport._
+import TypelevelCiPlugin.autoImport._
 import TypelevelSonatypePlugin.autoImport._
 
 object Http4sOrgPlugin extends AutoPlugin {
@@ -55,7 +56,13 @@ object Http4sOrgPlugin extends AutoPlugin {
   lazy val githubActionsSettings: Seq[Setting[_]] =
     Seq(
       githubWorkflowJavaVersions := List("8", "11", "17").map(JavaSpec.temurin(_)),
+      tlCiScalafixCheck := false, // we add our own, that skips Scala 3
       githubWorkflowBuildPostamble ++= Seq(
+        WorkflowStep.Sbt(
+          List("scalafixAll --check"),
+          name = Some("Check scalafix lints"),
+          cond = Some(s"${primaryJavaCond.value} && !startsWith(matrix.scala, '3.')")
+        ), 
         WorkflowStep.Sbt(
           List("unusedCompileDependenciesTest"),
           name = Some("Check unused compile dependencies"),

--- a/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
+++ b/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
@@ -62,7 +62,7 @@ object Http4sOrgPlugin extends AutoPlugin {
           List("scalafixAll --check"),
           name = Some("Check scalafix lints"),
           cond = Some(s"${primaryJavaCond.value} && !startsWith(matrix.scala, '3.')")
-        ), 
+        ),
         WorkflowStep.Sbt(
           List("unusedCompileDependenciesTest"),
           name = Some("Check unused compile dependencies"),


### PR DESCRIPTION
I didn't fully think this through in my other PR. Some of our special scalafixes are only supported on Scala 3, so we can't run the CI check in that case.