### PR TITLE
Set `scalafixScalaBinaryVersion`

### DIFF
--- a/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
+++ b/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
@@ -85,6 +85,7 @@ object Http4sOrgPlugin extends AutoPlugin {
 
   lazy val scalafixSettings: Seq[Setting[_]] =
     Seq(
+      scalafixScalaBinaryVersion := scalaBinaryVersion.value,
       scalafixDependencies ++= Seq(
         "org.http4s" %% "http4s-scalafix-internal" % "0.23.12",
         "com.github.liancheng" %% "organize-imports" % "0.6.0"


### PR DESCRIPTION
Ok, actually I have no idea about this. I rejected it in sbt-typelevel because it's only needed for fancy rules which we don't have on Scala 3 yet anyway.

In sbt-scalafix it says:
```scala
    val scalafixScalaBinaryVersion: SettingKey[String] =
      settingKey[String](
        "The Scala binary version used for scalafix execution. Must be set in ThisBuild. "
          + "Defaults to 2.12. Rules must be compiled against that binary version, or for "
          + "advanced rules such as ExplicitResultTypes which have a full cross-version, "
          + "against the corresponding full version that scalafix is built against."
      )
```
https://github.com/scalacenter/sbt-scalafix/blob/7697ec9f958ae3888720832e882d4f0c90a02386/src/main/scala/scalafix/sbt/ScalafixPlugin.scala#L65-L72

Which makes me think sometimes this should be a full Scala version, and not just the binary? 🤔 

In any case, we have this configured in the http4s build, and we don't check scalafixes on Scala 3, so probably good enough for us.
https://github.com/http4s/http4s/blob/113649a2241c0408045b8c2da25cb740b3318a25/build.sbt#L18
