### PR TITLE
Pin scala-native version

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,4 @@
 updates.pin = [
-  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." },
+  { groupId = "org.scala-native", artifactId = "sbt-scala-native", version = "0.4.0" }
 ]


### PR DESCRIPTION
So we don't force updates onto downstreams.