### PR TITLE
Pin Scala Native to `0.4.x`

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,4 @@
 updates.pin = [
   { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." },
-  { groupId = "org.scala-native", artifactId = "sbt-scala-native", version = "0.4.0" }
+  { groupId = "org.scala-native", artifactId = "sbt-scala-native", version = "0.4." }
 ]


### PR DESCRIPTION
A few reasons to do that:
1. `org.http4s.sbt.Http4sOrgScalaNativePlugin` isn't widely used across the organization (it's unused from my observations).
2. Every project under the organization that uses Scala Native is on the latest version of it. I.e. they update the SN version regularly.