### PR TITLE
bump http4s-scalafix-internal

### DIFF
--- a/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
+++ b/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
@@ -77,7 +77,7 @@ object Http4sOrgPlugin extends AutoPlugin {
   lazy val scalafixSettings: Seq[Setting[_]] =
     Seq(
       scalafixDependencies ++= Seq(
-        "org.http4s" %% "http4s-scalafix-internal" % "0.23.28"
+        "org.http4s" %% "http4s-scalafix-internal" % "0.23.29"
       )
     )
 


### PR DESCRIPTION
This PR + a new release of sbt-http4s-org will fix scalafix errors like those seen in this upgrade PR: https://github.com/http4s/http4s-netty/pull/713