### PR TITLE
import to fix local build failure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
+
 enablePlugins(TypelevelCiReleasePlugin)
 
 // Projects


### PR DESCRIPTION
Without this import, loading the build locally would fail with the following:
```
/Users/sam_1/src/github.com/http4s/sbt-http4s-org/build.sbt:14: error: No implicit for Remove.Value[explicitdeps.ModuleFilter, sbt.librarymanagement.ModuleFilter] found,
  so sbt.librarymanagement.ModuleFilter cannot be removed from explicitdeps.ModuleFilter
    unusedCompileDependenciesFilter -= moduleFilter("org.typelevel", "sbt-typelevel"),
                                    ^
sbt.compiler.EvalException: Type error in expression
```

I'm not sure why it hasn't been failing in CI though?