### PR TITLE
Prepare for Sonatype Central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         scala: [2.12]
-        java: [temurin@8, temurin@11, temurin@17]
+        java: [temurin@11, temurin@8, temurin@17]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -41,19 +41,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Setup Java (temurin@8)
-        id: setup-java-temurin-8
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt +update
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -66,6 +53,19 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Setup Java (temurin@8)
+        id: setup-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Setup Java (temurin@17)
@@ -85,38 +85,38 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
         run: sbt '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' doc
 
       - name: Check scalafix lints
-        if: matrix.java == 'temurin@8' && !startsWith(matrix.scala, '3')
+        if: matrix.java == 'temurin@11' && !startsWith(matrix.scala, '3')
         run: sbt '++ ${{ matrix.scala }}' 'scalafixAll --check'
 
       - name: Check unused compile dependencies
-        if: matrix.java == 'temurin@8'
+        if: matrix.java == 'temurin@11'
         run: sbt '++ ${{ matrix.scala }}' unusedCompileDependenciesTest
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         run: mkdir -p core/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         run: tar cf targets.tar core/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         uses: actions/upload-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
@@ -125,11 +125,11 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@8]
+        java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -139,19 +139,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Setup Java (temurin@8)
-        id: setup-java-temurin-8
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt +update
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -164,6 +151,19 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Setup Java (temurin@8)
+        id: setup-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Setup Java (temurin@17)
@@ -219,7 +219,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@8]
+        java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -229,19 +229,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Setup Java (temurin@8)
-        id: setup-java-temurin-8
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt +update
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -254,6 +241,19 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Setup Java (temurin@8)
+        id: setup-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Setup Java (temurin@17)
@@ -316,19 +316,6 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Setup Java (temurin@8)
-        id: setup-java-temurin-8
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt +update
-
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
@@ -340,6 +327,19 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Setup Java (temurin@8)
+        id: setup-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Setup Java (temurin@17)

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val docs = project
   .in(file("site"))
   .enablePlugins(Http4sOrgSitePlugin)
 
-ThisBuild / tlBaseVersion := "0.18"
+ThisBuild / tlBaseVersion := "1.0"
 ThisBuild / crossScalaVersions := Seq("2.12.20")
 ThisBuild / developers := List(
   Developer(

--- a/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
+++ b/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
@@ -22,6 +22,8 @@ import org.typelevel.sbt.gha._
 import sbt.Keys._
 import sbt._
 import scalafix.sbt.ScalafixPlugin.autoImport._
+import xerial.sbt.Sonatype.SonatypeKeys.sonatypeCredentialHost
+import xerial.sbt.Sonatype.sonatypeCentralHost
 
 import ExplicitDepsPlugin.autoImport._
 import GenerativeKeys._
@@ -52,7 +54,8 @@ object Http4sOrgPlugin extends AutoPlugin {
 
   lazy val githubActionsSettings: Seq[Setting[_]] =
     Seq(
-      githubWorkflowJavaVersions := List("8", "11", "17").map(JavaSpec.temurin(_)),
+      // 11 before 8 because sbt-sonatype needs to publish on >= 11
+      githubWorkflowJavaVersions := List("11", "8", "17").map(JavaSpec.temurin(_)),
       tlCiScalafixCheck := false, // we add our own, that skips Scala 3
       githubWorkflowBuildPostamble ++= Seq(
         WorkflowStep.Sbt(
@@ -66,7 +69,8 @@ object Http4sOrgPlugin extends AutoPlugin {
           cond = Some(primaryJavaCond.value)
         )
       ),
-      githubWorkflowBuildMatrixFailFast := Some(false)
+      githubWorkflowBuildMatrixFailFast := Some(false),
+      sonatypeCredentialHost := sonatypeCentralHost,
     )
 
   lazy val explicitDepsSettings: Seq[Setting[_]] =

--- a/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
+++ b/core/src/main/scala/org/http4s/sbt/Http4sOrgPlugin.scala
@@ -70,7 +70,7 @@ object Http4sOrgPlugin extends AutoPlugin {
         )
       ),
       githubWorkflowBuildMatrixFailFast := Some(false),
-      sonatypeCredentialHost := sonatypeCentralHost,
+      sonatypeCredentialHost := sonatypeCentralHost
     )
 
   lazy val explicitDepsSettings: Seq[Setting[_]] =


### PR DESCRIPTION
1. Set the publish host to Central
2. Publish with Java 11, as required by sbt-sonatype.  8 is still tested against.
3. Bump base version to 1.0.  Nothing's downstream of it anyway, so no reason to keep 0-vering it.