### PR TITLE
Temporarily reset credential host

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,10 @@
 enablePlugins(TypelevelCiReleasePlugin)
 
+// The plugin consumes its own settings.  Reset after the org is
+// reconfigured in Sonatype.
+sonatypeCredentialHost := "oss.sonatype.org"
+core / sonatypeCredentialHost := "oss.sonatype.org"
+
 // Projects
 lazy val `sbt-http4s-org` = project
   .in(file("."))


### PR DESCRIPTION
v1.0.0 didn't publish because the plugin consumes its own settings, and it tried to publish to Central before we've made the request to Sonatype.