### PR TITLE
Don't publish in "legacy Maven style"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,3 +30,6 @@ ThisBuild / developers := List(
     url("https://github.com/rossabaker"))
 )
 ThisBuild / startYear := Some(2020)
+
+// Remove cursed tag
+ThisBuild / tlMimaPreviousVersions ~= { prev => prev -- Set("1.0.0") }

--- a/build.sbt
+++ b/build.sbt
@@ -33,3 +33,5 @@ ThisBuild / startYear := Some(2020)
 
 // Remove cursed tag
 ThisBuild / tlMimaPreviousVersions ~= { prev => prev -- Set("1.0.0") }
+
+ThisBuild / sbtPluginPublishLegacyMavenStyle := false


### PR DESCRIPTION
First commit is not germane, but we can't republish the cursed tag anymore.